### PR TITLE
Add script to simplify installation of Tox repository

### DIFF
--- a/src/download.html
+++ b/src/download.html
@@ -120,7 +120,7 @@
 						After you've installed, try <a href="tox:56A1ADE4B65B86BCD51CC73E2CD4E542179F47959FE3E0E21B4B0ACDADE51855D34D34D37CB5">adding GroupBot</a>, and then <a href="#social">invite some friends</a>! Want to know more about the different clients? See our <a href="clients.html">clients list</a>.
 					</p>
 
-					<h6><a href="#warning">Note: Tox is still under heavy development — expect to run into some bugs.</a></h6>
+					<h5><a href="#warning">Note: Tox is still under heavy development — expect to run into some bugs.</a></h5>
 
 					<span id="defaultButton">
 						<a href="#oses" class="button large-button download">
@@ -208,11 +208,8 @@
 						<span class="text">Debian/Ubuntu</span>
 					</label>
 					<div class="tabdiv">
-						<p>For Debian, Ubuntu, Mint, and other distros using the apt package manager, you'll need to run the following commands to add our repository. Replace <b>$CODENAME</b> with the codename for the appropriate version of your distro (e.g jessie, stretch, trusty, vivid, etc.):</p>
-						<pre>echo "deb https://pkg.tox.chat/debian nightly $CODENAME" | sudo tee /etc/apt/sources.list.d/tox.list
-wget -qO - https://pkg.tox.chat/debian/pkg.gpg.key | sudo apt-key add -
-sudo apt-get install apt-transport-https
-sudo apt-get update</pre>
+						<p>For Debian, Ubuntu, Mint, and other distros using the apt package manager, you'll need to run the following <a href="tox-repository-installer.sh">script</a> to add our repository.</p>
+						<pre>wget -qO - https://beta.tox.chat/tox-repository-installer.sh | bash</pre>
 						<p>And to install (for example) qTox:</p>
 						<pre>sudo apt-get install qtox</pre>
 						<p>Or, if you have Ubuntu with Unity:</p>

--- a/src/tox-repository-installer.sh
+++ b/src/tox-repository-installer.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Tox repository installer
+ 
+# Figure out the version of Debian/Ubuntu that you're running
+CODENAME=`/usr/bin/lsb_release -cs`
+ 
+# All supported versions
+SUPPORTED_VERSIONS=("jessie" 
+                    "wheezy" 
+                    "xenial" 
+                    "wily"
+                    "vivid"
+                    "trusty")
+
+# If running operating system isn't supported -> Abort installation	              
+if [[ ! ${SUPPORTED_VERSIONS[*]} =~ "$CODENAME" ]]; then
+  echo "Your operating system isn't supported. Abort installation."
+  exit 0
+else
+  echo "Start installation of the Tox repository..."
+fi
+
+echo "deb https://pkg.tox.chat/debian nightly $CODENAME" | sudo tee /etc/apt/sources.list.d/tox.list
+wget -qO - https://pkg.tox.chat/debian/pkg.gpg.key | sudo apt-key add -
+sudo apt-get install apt-transport-https
+sudo apt-get update


### PR DESCRIPTION
Changes:
* Increase font-size of the warning because it was very hard to read
* Add script to simplify the installation of the repository for Debian based operating systems

Not everybody knows, what's the codename of the used operating system. 
So, this script simplifies it. However, maintenance for the script is necessary to change the supported versions regularly. But that shouldn't be much effort.

