### PR TITLE
Improve linux website instructions

### DIFF
--- a/src/download.html
+++ b/src/download.html
@@ -159,9 +159,9 @@
 					<img src="img/plat/linux_dark.svg">
 					<h2>Linux</h2>
 					<p class="lead"><a href="#gnulinux">Repo (Apt, Gentoo, Arch)</a></p>
-					<p class="lead" style="margin-top:-15px;"><a href="https://build.tox.chat/job/qTox_build_linux_x86_release/lastSuccessfulBuild/artifact/qTox_build_linux_x86_release.tar.xz">qTox 32 bit</a> | <a href="https://build.tox.chat/job/qTox_build_linux_x86-64_release/lastSuccessfulBuild/artifact/qTox_build_linux_x86-64_release.tar.xz">64 bit</a></p>
+					<p class="lead" style="margin-top:-15px;"><a href="#gnulinux">qTox package</a></p>
 					<p class="lead" style="margin-top:-15px;"><a href="https://build.tox.chat/job/uTox_build_linux_x86_release/lastSuccessfulBuild/artifact/utox_linux_x86.tar.xz">uTox 32 bit</a> | <a href="https://build.tox.chat/job/uTox_build_linux_x86-64_release/lastSuccessfulBuild/artifact/utox_linux_x86-64.tar.xz">64 bit</a></p>
-					<p class="lead" style="margin-top:-15px;"><a href="https://build.tox.chat/job/toxic_build_linux_x86_release/lastSuccessfulBuild/artifact/toxic_build_linux_x86_release.tar.xz">Toxic 32 bit</a> | <a href="https://build.tox.chat/job/toxic_build_linux_x86-64_release/lastSuccessfulBuild/artifact/toxic_build_linux_x86-64_release.tar.xz">64 bit</a></p>
+-					<p class="lead" style="margin-top:-15px;"><a href="#gnulinux">Toxic package</a>|<a href="https://build.tox.chat/job/toxic_build_linux_x86_release/lastSuccessfulBuild/artifact/toxic_build_linux_x86_release.tar.xz">32 bit binary</a> | <a href="https://build.tox.chat/job/toxic_build_linux_x86-64_release/lastSuccessfulBuild/artifact/toxic_build_linux_x86-64_release.tar.xz">64 bit binary</a></p>
 
 				</div>
 			</div>
@@ -208,7 +208,8 @@
 						<span class="text">Debian/Ubuntu</span>
 					</label>
 					<div class="tabdiv">
-						<p>For Debian, Ubuntu, Mint, and other distros using the apt package manager, you'll need to run the following commands to add our repository.</p>
+						<p>For distributions utilising the deb package format, you'll need to run the following commands to add our repository.</p>
+						<p>Please note that only Debian (Sid, Jessie and Stretch) and Ubuntu (Vivid and Wily) are officially supported. If your distribution is not supported you can find compilation instructions on client repos (check <a href="clients.html">the clients page</a>).</p>
 						<pre>echo "deb https://pkg.tox.chat/debian nightly $(lsb_release -cs)" | sudo tee /etc/apt/sources.list.d/tox.list
 wget -qO - https://pkg.tox.chat/debian/pkg.gpg.key | sudo apt-key add -
 sudo apt-get install apt-transport-https


### PR DESCRIPTION
Update repo instructions to clearly indicate which repositories are supported.

* We're currently being very misleading as to exactly which distributions are being supported
* The static builds for qtox are explicitly not being maintained - tux3 was quite clear on this point.
* Thinking the static packages will work well or even run at all is naive really, ABI compatibility between distributions is extremely poor. In general I would like to get rid of them completely - I'd rather we only provide *proper* pbuilder packages and the windows builds with their updaters.
* I'd rather not continue to tell people about the "release" codename for the same reasons

We're overstretching ourselves trying to pretend we support a lot more distributions than we actually can or have people to do. Also this frees up Jenkins from pretending to do continuous integration - a far better solution is travis CI.

This should be merged in tandem with updates to the wiki binaries page.

Fixes #84