### PR TITLE
Fix footer of About page

### DIFF
--- a/src/about.html
+++ b/src/about.html
@@ -265,7 +265,8 @@ the meaning of Section 501(c)(3) of the Internal Revenue Code.</pre>
 			<div class="ext-med pull-left">
 				<a class="button" href="https://twitter.com/projecttox" title="Follow us on Twitter"><span class="icon fa fa-twitter"></span></a>
 				<a class="button" href="https://www.facebook.com/toxproject" title="Like us on Facebook"><span class="icon fa fa-facebook"></span></a>
-				<a class="button" href="https://blog.tox.chat/" title="Subscribe to our blog"><span class="icon fa fa-rss"></span></a>
+				<a class="button" href="https://github.com/irungentoo/toxcore" title="Star us on Github"><span class="icon fa fa-github"></span></a>
+				<a class="button" href="https://wiki.tox.chat/users/community#irc" title="Chat with us on IRC"><span class="icon fa fa-comments"></span></a>
 				<a class="button do-button" href="https://www.digitalocean.com/" title="Proudly hosted by DigitalOcean"><img class="button" src="img/do.svg" /></a>
 			</div>
 


### PR DESCRIPTION
The social media buttons on About page were different from all other pages, which shouldn't be the case.