### PR TITLE
Changed Antox APK download URL

### DIFF
--- a/themes/website/static/js/osdetect.js
+++ b/themes/website/static/js/osdetect.js
@@ -124,7 +124,7 @@ if (window.navigator.userAgent.indexOf("Android") != -1) {
 		name: "antox",
 		icon: "download",
 		desc: true,
-		dlLink: "https://build.tox.chat/job/antox_build_android_arm_release/lastSuccessfulBuild/artifact/antox.apk",
+		dlLink: "https://pkg.tox.chat/fdroid/repo/antox.apk",
 	}];
 }
 

--- a/themes/website/templates/download.html
+++ b/themes/website/templates/download.html
@@ -76,7 +76,7 @@
 					<img src="theme/img/plat/android_dark.svg">
 					<h2>Android</h2>
 					<p class="lead"><a href="#fdroid">Antox (F-droid)</a></p>
-					<p class="lead" style="margin-top:-15px;"><a href="https://build.tox.chat/job/antox_build_android_arm_release/lastSuccessfulBuild/artifact/antox.apk">Antox (APK)</a></p>
+					<p class="lead" style="margin-top:-15px;"><a href="https://pkg.tox.chat/fdroid/repo/antox.apk">Antox (APK)</a></p>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Since we have recently removed .apk signing off Jenkins, the Antox .apk we link to is no longer signed, which causes issues https://github.com/Antox/Antox/issues/319. The .apk we have in our F-Droid repository is the same .apk as on Jenkins but signed, so we should link to that instead.