### PR TITLE
Update uTox OS X download link

### DIFF
--- a/themes/website/static/js/osdetect.js
+++ b/themes/website/static/js/osdetect.js
@@ -46,7 +46,7 @@ if (window.navigator.userAgent.indexOf("Mac") != -1) {
 		name: "utox",
 		icon: "download",
 		desc: true,
-		dlLink: "https://zodiaclabs.org/storage/c1/uTox-0.4.2.dmg",
+		dlLink: "https://github.com/uTox/uTox/releases/download/v0.9.8/uTox-0.9.8.dmg",
 	}];
 }
 

--- a/themes/website/templates/download.html
+++ b/themes/website/templates/download.html
@@ -43,7 +43,7 @@
 				<div class="col-sm-4 feature">
 					<img src="theme/img/plat/mac_dark.svg">
 					<h2>OS X</h2>
-					<p class="lead"><a href="https://github.com/GrayHatter/uTox/releases/download/v0.7.0/uTox-0.7.0.dmg">uTox 64 bit (OS X 10.7+)</a></p>
+					<p class="lead"><a href="https://github.com/uTox/uTox/releases/download/v0.9.8/uTox-0.9.8.dmg">uTox 64 bit (OS X 10.7+)</a></p>
 				</div>
 
 				<div class="col-sm-4 feature">


### PR DESCRIPTION
The provided versions are too old, the `uTox-0.7.0.dmg` link doesn't work and `uTox-0.4.2.dmg` sounds pre-historic.