### PR TITLE
Updated download page

### DIFF
--- a/themes/website/static/css/style.css
+++ b/themes/website/static/css/style.css
@@ -305,7 +305,7 @@ tbody th:first-child, thead th {
 #cover .button.download {
 	background: #FFBA2B;
 	color: #fff;
-	width: 190px;
+	width: 210px;
 }
 
 #cover .button.download:hover {

--- a/themes/website/static/js/osdetect.js
+++ b/themes/website/static/js/osdetect.js
@@ -42,7 +42,7 @@ if (window.navigator.userAgent.indexOf("Mac") != -1) {
 	OSName = "Mac";
 
 	clients = [{
-		title: "Download uTox",
+		title: "uTox 64-bit",
 		name: "utox",
 		icon: "download",
 		desc: true,
@@ -54,7 +54,7 @@ if (window.navigator.userAgent.indexOf("iPad") != -1) {
 	OSName = "iOS";
 
 	clients = [{
-		title: "Install Antidote",
+		title: "Antidote",
 		name: "antidote",
 		icon: "external-link",
 		desc: true,
@@ -66,7 +66,7 @@ if (window.navigator.userAgent.indexOf("iPhone") != -1) {
 	OSName = "iOS";
 
 	clients = [{
-		title: "Install Antidote",
+		title: "Antidote",
 		name: "antidote",
 		icon: "external-link",
 		desc: true,
@@ -78,11 +78,17 @@ if (window.navigator.userAgent.indexOf("Linux") != -1) {
 	OSName = "Linux";
 
 	clients = [{
-		title: "Install Repo",
+		title: "Our repository",
 		name: "repo",
 		icon: "list-ul",
 		desc: false,
 		dlLink: "#gnulinux",
+	},  {
+		title: "qTox repository",
+		name: "qtox",
+		icon: "external-link",
+		desc: true,
+		dlLink: "https://software.opensuse.org/download.html?project=home%3Aantonbatenev%3Atox&package=qtox",
 	}];
 }
 
@@ -114,11 +120,17 @@ if (window.navigator.userAgent.indexOf("Android") != -1) {
 	OSName = "Android";
 
 	clients = [{
-		title: "Install Antox",
+		title: "Antox F-Droid",
 		name: "antox",
 		icon: "external-link",
 		desc: true,
 		dlLink: "#fdroid",
+	}, {
+		title: "Antox Google Play",
+		name: "antox",
+		icon: "external-link",
+		desc: true,
+		dlLink: "https://play.google.com/store/apps/details?id=chat.tox.antox",
 	}, {
 		title: "Antox APK",
 		name: "antox",

--- a/themes/website/templates/download.html
+++ b/themes/website/templates/download.html
@@ -36,8 +36,9 @@
 				<div class="col-sm-4 feature">
 					<img src="theme/img/plat/windows_dark.svg">
 					<h2>Windows</h2>
-					<p class="lead"><a href="https://build.tox.chat/view/qtox/job/qTox_pkg_windows_x86_stable_release/lastSuccessfulBuild/artifact/setup-qtox.exe">qTox 32 bit</a> | <a href="https://build.tox.chat/view/qtox/job/qTox_pkg_windows_x86-64_stable_release/lastSuccessfulBuild/artifact/setup-qtox.exe">64 bit</a></p>
-					<p class="lead" style="margin-top:-15px;"><a href="https://build.tox.chat/job/uTox_build_windows_x86_release/lastSuccessfulBuild/artifact/utox_windows_x86.zip"> uTox 32 bit</a> | <a href="https://build.tox.chat/job/uTox_build_windows_x86-64_release/lastSuccessfulBuild/artifact/utox_windows_x86-64.zip">64 bit</a></p>
+					<p class="lead">qTox stable: <a href="https://build.tox.chat/view/qtox/job/qTox_pkg_windows_x86_stable_release/lastSuccessfulBuild/artifact/setup-qtox.exe">32 bit</a> / <a href="https://build.tox.chat/view/qtox/job/qTox_pkg_windows_x86-64_stable_release/lastSuccessfulBuild/artifact/setup-qtox.exe">64 bit</a></p>
+					<p class="lead" style="margin-top:-15px;">qTox nightly: <a href="https://build.tox.chat/view/qtox/job/qTox_build_windows_x86_release/lastSuccessfulBuild/artifact/qTox_build_windows_x86_release.zip">32 bit</a> / <a href="https://build.tox.chat/view/qtox/job/qTox_build_windows_x86-64_release/lastSuccessfulBuild/artifact/qTox_build_windows_x86-64_release.zip">64 bit</a></p>
+					<p class="lead" style="margin-top:-15px;">uTox stable: <a href="https://build.tox.chat/job/uTox_build_windows_x86_release/lastSuccessfulBuild/artifact/utox_windows_x86.zip"> 32 bit</a> / <a href="https://build.tox.chat/job/uTox_build_windows_x86-64_release/lastSuccessfulBuild/artifact/utox_windows_x86-64.zip">64 bit</a></p>
 				</div>
 
 				<div class="col-sm-4 feature">
@@ -49,10 +50,11 @@
 				<div class="col-sm-4 feature">
 					<img src="theme/img/plat/linux_dark.svg">
 					<h2>Linux</h2>
-					<p class="lead"><a href="#gnulinux">Repo (Apt, Gentoo, Arch)</a></p>
-					<p class="lead" style="margin-top:-15px;"><a href="#gnulinux">qTox package</a></p>
-					<p class="lead" style="margin-top:-15px;"><a href="https://build.tox.chat/job/uTox_build_linux_x86_release/lastSuccessfulBuild/artifact/utox_linux_x86.tar.xz">uTox 32 bit</a> | <a href="https://build.tox.chat/job/uTox_build_linux_x86-64_release/lastSuccessfulBuild/artifact/utox_linux_x86-64.tar.xz">64 bit</a></p>
-					<p class="lead" style="margin-top:-15px;"><a href="#gnulinux">Toxic package</a>|<a href="https://build.tox.chat/job/toxic_build_linux_x86_release/lastSuccessfulBuild/artifact/toxic_build_linux_x86_release.tar.xz">32 bit binary</a> | <a href="https://build.tox.chat/job/toxic_build_linux_x86-64_release/lastSuccessfulBuild/artifact/toxic_build_linux_x86-64_release.tar.xz">64 bit binary</a></p>
+					<p class="lead"><a href="#gnulinux">Ricin, Toxic, Toxygen and uTox Debian/Ubuntu repo</a></p>
+					<p class="lead" style="margin-top:-15px;"><a href="https://software.opensuse.org/download.html?project=home%3Aantonbatenev%3Atox&package=qtox">qTox repo (Arch, CentOS, Debian, Fedora, openSUSE, Ubuntu)</a></p>
+					<p class="lead" style="margin-top:-15px;"><a href="#gnulinux">Arch and Gentoo repos (not maintained)</a></p>
+					<p class="lead" style="margin-top:-15px;">uTox static: <a href="https://build.tox.chat/job/uTox_build_linux_x86_release/lastSuccessfulBuild/artifact/utox_linux_x86.tar.xz">32 bit</a> / <a href="https://build.tox.chat/job/uTox_build_linux_x86-64_release/lastSuccessfulBuild/artifact/utox_linux_x86-64.tar.xz">64 bit</a></p>
+					<p class="lead" style="margin-top:-15px;">Toxic static: <a href="https://build.tox.chat/job/toxic_build_linux_x86_release/lastSuccessfulBuild/artifact/toxic_build_linux_x86_release.tar.xz">32 bit</a> / <a href="https://build.tox.chat/job/toxic_build_linux_x86-64_release/lastSuccessfulBuild/artifact/toxic_build_linux_x86-64_release.tar.xz">64 bit</a></p>
 
 				</div>
 			</div>
@@ -75,8 +77,7 @@
 				<div class="col-sm-4 feature">
 					<img src="theme/img/plat/android_dark.svg">
 					<h2>Android</h2>
-					<p class="lead"><a href="#fdroid">Antox (F-droid)</a></p>
-					<p class="lead" style="margin-top:-15px;"><a href="https://pkg.tox.chat/fdroid/repo/antox.apk">Antox (APK)</a></p>
+					<p class="lead">Antox: <a href="#fdroid">F-Droid</a> / <a href="https://play.google.com/store/apps/details?id=chat.tox.antox">Google Play</a> / <a href="https://pkg.tox.chat/fdroid/repo/antox.apk">APK</a></p>
 				</div>
 			</div>
 		</div>
@@ -100,15 +101,19 @@
 					</label>
 					<div class="tabdiv">
 						<p>For distributions utilising the deb package format, you'll need to run the following commands to add our repository.</p>
-						<p>Please note that only Debian (Sid, Jessie and Stretch) and Ubuntu (Vivid and Wily) are officially supported. If your distribution is not supported you can find compilation instructions on client repos (check <a href="clients.html">the clients page</a>).</p>
+						<p>Please note that only Debian (8/Jessie, 9/Stretch and Sid) and Ubuntu (15.04/Vivid, 15.10/Wily and 16.04/Xenial) are officially supported. If your distribution is not supported you can find compilation instructions on client repos (check <a href="clients.html">the clients page</a>).</p>
+						<p>For stable client releases, use the following commands:</p>
+						<pre>echo "deb https://pkg.tox.chat/debian stable $(lsb_release -cs)" | sudo tee /etc/apt/sources.list.d/tox.list
+wget -qO - https://pkg.tox.chat/debian/pkg.gpg.key | sudo apt-key add -
+sudo apt-get install apt-transport-https
+sudo apt-get update</pre>
+						<p>For nightly client releases, use the following commands:</p>
 						<pre>echo "deb https://pkg.tox.chat/debian nightly $(lsb_release -cs)" | sudo tee /etc/apt/sources.list.d/tox.list
 wget -qO - https://pkg.tox.chat/debian/pkg.gpg.key | sudo apt-key add -
 sudo apt-get install apt-transport-https
 sudo apt-get update</pre>
-						<p>And to install (for example) qTox:</p>
-						<pre>sudo apt-get install qtox</pre>
-						<p>Or, if you have Ubuntu with Unity:</p>
-						<pre>sudo apt-get install qtox-unity</pre>
+						<p>And to install (for example) uTox:</p>
+						<pre>sudo apt-get install utox</pre>
 						<p>To see all available packages:</p>
 						<pre>cat /var/lib/apt/lists/pkg.tox.chat* | grep "Package: "</pre>
 					</div>
@@ -149,9 +154,9 @@ sudo apt-get update</pre>
 				<a href="#close" class="close-overlay"></a>
 				<a href="#close" title="Close" class="close"><span class="fa fa-close">&nbsp;</span></a>
 
-				<h2>F-droid</h2>
+				<h2>F-Droid</h2>
 
-				<p>Add the repo to <a href='https://f-droid.org/' target='_blank'>F-droid:</a></p>
+				<p>Add our F-Droid repo in the <a href='https://f-droid.org/' target='_blank'>F-Droid app</a></p>
 				<pre>https://pkg.tox.chat/fdroid/repo</pre>
 				<p>Then search for Antox, and enjoy.</p>
 			</div>


### PR DESCRIPTION
Just a small update to keep the page up-to-date until the download page redesign is done.

- added link to [qTox's repository](https://software.opensuse.org/download.html?project=home%3Aantonbatenev%3Atox&package=qtox)
- added instructions for `stable` Debian/Ubuntu repository
- mentioned support of Xenial
- added qTox nightly download links (why not?)
- added Antox Google Play link
- fixed formatting a little, from `Client name 32 bit | 64 bit` and `Client name 32 bit | Client name 64 bit` to `Client name: 32 bit / 64 bit`

[I have temporary hosted the PR for you to test](http://198.46.138.44/).