### PR TITLE
Updated download-page to include a developer section. (issue #130)

### DIFF
--- a/themes/website/static/img/plat/plain.svg
+++ b/themes/website/static/img/plat/plain.svg
@@ -19,7 +19,7 @@
    enable-background="new 0 0 90 109"
    xml:space="preserve"
    inkscape:version="0.48.5 r10040"
-   sodipodi:docname="linux.svg"><metadata
+   sodipodi:docname="plain.svg"><metadata
      id="metadata11"><rdf:RDF><cc:Work
          rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs

--- a/themes/website/static/img/plat/plain_dark.svg
+++ b/themes/website/static/img/plat/plain_dark.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 15.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="90px"
+   height="109px"
+   viewBox="-1 -1 92 111"
+   enable-background="new 0 0 90 109"
+   xml:space="preserve"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="plain_dark.svg"><metadata
+     id="metadata11"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+     id="defs9" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1680"
+     inkscape:window-height="1011"
+     id="namedview7"
+     showgrid="false"
+     inkscape:snap-bbox="false"
+     inkscape:zoom="6.123934"
+     inkscape:cx="66.398595"
+     inkscape:cy="20.240216"
+     inkscape:window-x="0"
+     inkscape:window-y="20"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Layer_1" /><g
+     id="g3"
+     style="stroke:#414141;stroke-opacity:1"><path
+       d="m 71.574,41.851 c 0,-4.685 0.074,-10.553 -0.033,-15.237 C 71.494,24.596 71.273,22.538 70.795,20.58 67.374,6.581 53.823,-2.125 39.594,0.45 26.998,2.729 17.621,13.968 17.621,26.786 l 0,13.865 0,1.17 c -0.475,0 -0.794,-10e-4 -1.116,0 l -11.482,0 C 2.25,41.821 0,44.07 0,46.844 l 0,56.875 c 0,2.773 2.25,5.023 5.023,5.023 l 79.451,0 c 2.775,0 5.024,-2.25 5.024,-5.023 l 0,-56.875 c 0,-2.774 -2.249,-5.023 -5.024,-5.023 z m -9.795,-8.747 c -1.562,4.611 -4.52,8.305 -7.61,11.912 -2.386,2.783 -5.19,5.125 -8.176,7.247 -0.144,0.103 -0.298,0.188 -0.685,0.427 1.781,-3.076 3.217,-5.998 3.633,-9.404 -4.234,1.002 -8.227,0.564 -12.093,-1.14 -6.862,-3.023 -10.963,-9.618 -10.263,-17.063 0.573,-6.127 3.94,-10.543 9.321,-13.395 8.667,-4.593 19.734,-1.655 24.689,6.516 2.887,4.758 2.932,9.741 1.184,14.9"
+       id="path5"
+       style="fill:#414141;fill-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccscccssssssscccccccccccc" /></g></svg>

--- a/themes/website/static/img/plat/unknown_dark.svg
+++ b/themes/website/static/img/plat/unknown_dark.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 15.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="90px"
+   height="109px"
+   viewBox="-1 -1 92 111"
+   enable-background="new 0 0 90 109"
+   xml:space="preserve"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="unknown_dark.svg"><metadata
+     id="metadata11"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+     id="defs9" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1278"
+     inkscape:window-height="595"
+     id="namedview7"
+     showgrid="false"
+     inkscape:snap-bbox="false"
+     inkscape:zoom="2.1651376"
+     inkscape:cx="-11.973612"
+     inkscape:cy="54.5"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="Layer_1" /><g
+     id="g3"
+     style="stroke:#414141;stroke-opacity:1"><path
+       d="M71.574,41.851c0-4.685,0.074-10.553-0.033-15.237c-0.047-2.018-0.268-4.076-0.746-6.034   C67.374,6.581,53.823-2.125,39.594,0.45C26.998,2.729,17.621,13.968,17.621,26.786v13.865v1.17c-0.475,0-0.794-0.001-1.116,0H5.023   C2.25,41.821,0,44.07,0,46.844v56.875c0,2.773,2.25,5.023,5.023,5.023h79.451c2.775,0,5.024-2.25,5.024-5.023V46.844   c0-2.774-2.249-5.023-5.024-5.023L71.574,41.851z M52.107,95.118H37.332c-2.322,0-4.203-1.914-4.203-4.274   c0-0.063,0.007-0.127,0.009-0.19c-0.005,0-0.006-1.021-0.008-2.041c-0.001-1.129,0.511-4.289,2.061-6.574   c1.641-2.418,3.855-3.99,6.257-4.697c-3.166-1.291-5.396-4.398-5.396-8.025c0-4.789,3.88-8.668,8.667-8.668   c4.789,0,8.667,3.879,8.667,8.668c0,3.719-2.344,6.891-5.637,8.12c2.332,0.753,4.537,2.313,6.273,4.707   c1.621,2.235,2.285,5.343,2.285,6.47v2.043c-0.006,0.062,0,0.125,0,0.189C56.308,93.204,54.427,95.118,52.107,95.118    M61.779,33.104c-1.562,4.611-4.52,8.305-7.61,11.912c-2.386,2.783-5.19,5.125-8.176,7.247c-0.144,0.103-0.298,0.188-0.685,0.427   c1.781-3.076,3.217-5.998,3.633-9.404c-4.234,1.002-8.227,0.564-12.093-1.14c-6.862-3.023-10.963-9.618-10.263-17.063   c0.573-6.127,3.94-10.543,9.321-13.395c8.667-4.593,19.734-1.655,24.689,6.516C63.482,22.962,63.527,27.945,61.779,33.104"
+       id="path5"
+       style="fill:#414141;fill-opacity:1" /></g></svg>

--- a/themes/website/templates/_base.html
+++ b/themes/website/templates/_base.html
@@ -57,7 +57,7 @@
       <div class="ext-med pull-left">
         <a class="button" href="https://twitter.com/projecttox" title="Follow us on Twitter"><span class="icon fa fa-twitter"></span></a>
         <a class="button" href="https://www.facebook.com/toxproject" title="Like us on Facebook"><span class="icon fa fa-facebook"></span></a>
-        <a class="button" href="https://github.com/irungentoo/toxcore" title="Star us on Github"><span class="icon fa fa-github"></span></a>
+        <a class="button" href="https://github.com/TokTok/c-toxcore" title="Star us on Github"><span class="icon fa fa-github"></span></a>
         <a class="button" href="https://wiki.tox.chat/users/community#irc" title="Chat with us on IRC"><span class="icon fa fa-comments"></span></a>
         <a class="button do-button" href="https://www.digitalocean.com/" title="Powered by DigitalOcean"><img class="button" src="theme/img/do.svg" /></a>
       </div>

--- a/themes/website/templates/download.html
+++ b/themes/website/templates/download.html
@@ -90,9 +90,15 @@
 		<div class="container-fluid limit-width">
 			<div class="row">
 				<div class="col-sm-6 feature">
-					<h2>Toxcore development repositories</h2>
-					<p class="lead"><a href="https://github.com/irungentoo/toxcore">irungentoo/toxcore</a></p>
-					<p class="lead"><a href="https://github.com/TokTok/c-toxcore">TokTok/c-toxcore</a></p>
+					<h2>Toxcore</h2>
+					<p class="lead">
+						<a href="https://github.com/irungentoo/toxcore">irungentoo/toxcore</a>
+						<a class="button" href="#irungentoo-toxcore" title="More info"><span class="fa fa-info-circle"></span></a>
+					</p>
+					<p class="lead" style="margin-top:-15px;">
+						<a href="https://github.com/TokTok/c-toxcore">TokTok/c-toxcore</a>
+						<a class="button" href="#toktok-c-toxcore" title="More info"><span class="fa fa-info-circle"></span></a>
+					</p>
 				</div>
 
 				<div class="col-sm-6 feature">
@@ -102,6 +108,7 @@
 					<p class="lead" style="margin-top:-15px;">Java/Scala: <a href="https://github.com/TokTok/jvm-toxcore-c">jvm-toxcore-c</a></p>
 					<p class="lead" style="margin-top:-15px;">Objective-C/Swift: <a href="https://github.com/Antidote-for-Tox/objcTox">objcTox</a></p>
 					<p class="lead" style="margin-top:-15px;">Python: <a href="https://github.com/aitjcize/PyTox">PyTox</a> / <a href="https://github.com/abbat/pytoxcore">pytoxcore</a></p>
+					<p class="lead" style="margin-top:-15px;">Rust: <a href="https://github.com/ze-tox/tox-capi">tox-capi</a></p>
 					<p class="lead" style="margin-top:-15px;">Vala: <a href="https://git.ricin.im/Ricin/tox-vapis">Tox VAPIs</a></p>
 				</div>
 			</div>
@@ -183,6 +190,7 @@ sudo apt-get update</pre>
 
 				<p>Add our F-Droid repo in the <a href="https://f-droid.org/" target="_blank">F-Droid app</a>:</p>
 				<pre><a href="https://pkg.tox.chat/fdroid/repo?fingerprint=9F777DD77C7F768269848233CF83D44F5C4FE480D7D5CB1CF32820B23A1AF086">https://pkg.tox.chat/fdroid/repo</a></pre>
+				<!-- Move this image to a file. -->
 				<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPoAAAD6CAYAAACI7Fo9AAAKq0lEQVR4nO2dSY4cMQwE/af5/9vaFx9qDLenWkwmU6UIQDdJXMSoQ8PG/HoBwOP5NZ0AAPSD6AAHgOgAB4DoAAeA6AAHgOgAB4DoAAeA6AAHgOgAB4DoAAeA6AAHgOgAB4DoAAeA6AAHgOgAB4DoAAeA6AAHgOgAB4DoAAeA6AAHgOgAB9Am+tfXV8y6m1+lDnWvKvvUMZJ66uh90pyqQPTGoaz0qrJPHSOpp47eJ82pCkRvHMpKryr71DGSeurofdKcqkD0xqGs9KqyTx0jqaeO3ifNqQpEbxzKSq8q+9Qxknrq6H3SnKqwiu5APWzpA+jogbqOyj51HelzqgLRER3Rg+dUBaIjOqIHz6kKREd0RA+eUxWIjuiIHjynKsZFnxLOMVhJQ+RYjjqmYkzNqQpER3RED55TFYiO6IgePKcqEB3RET14TlUgOqIjevCcqkD0gPymzk7FUFOJmzQHnSB6QH5JEu40vIq4SXPQCaIH5Jck4U7Dq4ibNAedIHpAfkkS7jS8irhJc9AJogfklyThTsOriJs0B50cK7r6bKU2R4yk/jl64MgZ0V97NhDREX2HOV0B0UVnK7U5YiT1D9ERfYtBrdyH6IhezXkFRBedrdTmiJHUP0Q/UPSpuA4JKziGyFGvI+edhJuKi+iIjujBc6oC0REd0YPnVAWiIzqiB8+pCkRHdEQPnlMV/KUW9rEvZHWC6OxjX8jqBNHZx76Q1Qmis499IasTRGcf+0JWJ22i74h6OCpxHQOTNJRJuTwRRL+A6Ij+VBD9AqIj+lNB9AuIjuhPBdEvIDqiP5XxX93V96kHQR1X/TFR56Kuo4KjDkfchA8WopvjJg0RonviIjqiI/p/QHQdiG6OmzREiO6Ji+iIjuj/AdF1RP5/9CRppu5TkySNe8gV+SW95QqIjuhLtVXiJsmw41uugOiIvlRbJW6SDDu+5QqIjuhLtVXiJsmw41uugOiIvlRbJW6SDDu+5QqP+yewU0PpiKseokrc9D5P7buL+4OA6D+cRXRE/2TfXRC9SPoAVuIiOqKvgug/nEV0RP9k310QvUj6AFbiIjqirxL5q7uDHR9YLWbSh01d71RPU0F0REd0RF8nvQmIjugdPU0F0REd0RF9nfQmIDqid/Q0Feuv7g5ppgZ1ajimclH3+Sm5pILoiL69XEm5pILoiL69XEm5pILoiL69XEm5pILoiL69XEm5pBL5q7uj0Q4J1fk95Wx6DHXchFlDdES3n02PoY6bMGuIjuj2s+kx1HETZg3REd1+Nj2GOm7CrCE6otvPpsdQx02YtXHR1U2o3Lej6Op61YOqjuEQ2DFDiI7oH+WSJKEjBqKvgegLOTtAdERXgugLOTtAdERXgugLOTtAdERX8jjR1bmoY1RwSKN+j/SeOnDM+E8g+sI+9dlKDETPB9Hf7EP0+zEQPR9Ef7MP0e/HQPR8EP3NPkS/HwPR8zlO9ErBjkGd+iCkfyTu3jeV81R+d0nIBdF/iFHZV6lDDaIjeguIXuuLGkRH9BYQvdYXNYiO6C0geq0vahAd0W1MPZJaLoesUx+2qQ9l+myoe+UG0REd0RFdS/pjTt1XiYHoWX1G9Beid+SM6Fl9RvQXonfkjOhZfT5O9KlmORo9JdJULg7RKzlXejUlq/uDgOii2u7uQ3REf5dLJ4guqu3uPkRH9He5dILootru7kN0RH+XSyeILqrt7j5ER/R3uXQy/qv7VPOTBnoKRw8qcZM+COoeuEF0REf0xdrS3/cKoiM6oi/Wlv6+VxAd0RF9sbb0972C6IiO6Iu1pb/vFavod3EMkSM/x7BVSJJafVbNTlL/C0RvzA/RET0FRG/MD9ERPQVEb8wP0RE9BURvzA/RET2F8V/dp1AP+d2hdHx0HHKpa5u6z1FvwgcL0RFddh+iI/rr9UJ0RK/X4egLohdBdESv1uHoC6IXQXREr9bh6Auif0BSU5Nqq+ScFEMtoePsaTGuILq5tkrOSTEQPT/GFUQ311bJOSkGoufHuILo5toqOSfFQPT8GFcQ3VxbJeekGIieH+PK+K/uTxZzKr/0uI5cpupIzQXRER3Rm0nIBdERHdGbScgF0REd0ZtJyAXRER3Rm0nIxfqruyPGjlKr4zpkmHrfSh071qYC0RE9oi+OOnasTQWiI3pEXxx17FibCkRH9Ii+OOrYsTYViI7oEX1x1LFjbSq2Fr2Si3oQpgYrPcZUr9S5OFYniI7orTEQHdFtIDqi77A6QXREb42B6IhuA9ERfYfVSeQ/gVUPpbqpU/c5ZL171pFL0lsi+gcgeu0+REf0VRBdVIfjPkRH9FUQXVSH4z5ER/RVEF1Uh+M+REf0VcZ/dZ8amAqVh3MMlvo+91B+mrPjvqkeqED0BRAd0RH9D4iO6FUQXQeiL4DoiI7of0B0RK+C6Dqsv7pXcAx+Un6VuJV9jtqSPhxJ+XWC6Ihurw3R/SA6ottrQ3Q/iI7o9toQ3Q+iI7q9NkT3M/6ru+O+ygM74k6ddQy0OpenfMjdHxNE/2FfuqyVs4heqwPRX4juyrlyFtFrdSD6C9FdOVfOInqtDkR/Ibor58pZRK/VgehF1EOeJJz6o5MUQ51f5T3UPXCc7QTRQ3NB9Np7IPp3ED00F0SvvQeifwfRQ3NB9Np7IPp3ED00F0SvvQeif2dcdEdTK3Gn7qvEcAhXyXnqg5A0Q4iO6OUYiI7of4PoiI7oiN4PoutjIDqi/w2iIzqiI/o66gdWP1zSA6sFnsqlsk8dY8fVCaI3DmClL+qzjlwq+9QxdlydIHrjAFb6oj7ryKWyTx1jx9UJojcOYKUv6rOOXCr71DF2XJ0geuMAVvqiPuvIpbJPHWPH1cn4r+5TpD/ck6VOyuUu6pwR3QSiI/onIPqmIDqifwKibwqiI/onIPqmIDqifwKiv8Eh0lQD1Q+sFlhNkujq+6ZqQ3RER3REl4PootrUPVDnUgHRs958BUQX1abugTqXCoie9eYrILqoNnUP1LlUQPSsN19hm7/Uoo7r+JhM9aCSy1Rt6vdw5Oc4qwLREb11XyU/RNeB6Ijeuq+SH6LrQHREb91XyQ/RdSA6orfuq+SH6DrGRZ+SK130Hc9W7lPnPLVSQXREl52t3IfovSA6osvOVu5D9F4QHdFlZyv3IXoviI7osrOV+xC9l2NFVzOV39QHa8cPkWM2UucU0UUger6siN4AoiP6Jzmnn1XHQHREL8dFdP1ZdQxER/RyXETXn1XHQPRB0Z88+El9SVrqXql7qgLRG3NWx1Xn7IiRvtS9UvdUBaI35qyOq87ZESN9qXul7qkKRG/MWR1XnbMjRvpS90rdUxWI3pizOq46Z0eM9KXulbqnKsZFn4rrGBhHXEcuFdTvocYh/1RtVxA9VK6kXCogOqKPxk2XKymXCoiO6KNx0+VKyqUCoiP6aNx0uZJyqYDoB4o+tdT5qfvi6F8lRqWOSl/UcjniVnLpBNERHdFD3rwTREd0RA95804QHdERPeTNO0F0REf0kDfvpE10AMgB0QEOANEBDgDRAQ4A0QEOANEBDgDRAQ4A0QEOANEBDgDRAQ4A0QEOANEBDgDRAQ4A0QEOANEBDgDRAQ4A0QEOANEBDgDRAQ4A0QEOANEBDgDRAQ4A0QEO4DcrWUGgtsBqrwAAAABJRU5ErkJggg==">
 				<p>Then search for Antox, and enjoy.</p>
 				<br>
@@ -243,6 +251,28 @@ sudo apt-get update</pre>
 						</a>
 					</div>
 				</section>
+			</div>
+		</div>
+
+		<div id="irungentoo-toxcore" class="modalDialog button">
+			<div>
+				<a href="#close" class="close-overlay"></a>
+				<a href="#close" title="Close" class="close"><span class="fa fa-close">&nbsp;</span></a>
+
+				<h2>irungentoo/toxcore</h2>
+
+				<p class="lead">irungentoo/toxcore is the original Toxcore. This repository is not active because any change to Toxcore should be first reviewed and approved by irungentoo, as he is the only one who can merge changes, but irungentoo has been very busy lately and unable to find time to work on Toxcore. He only finds time to fix bugs in Toxcore. Also, this is the Toxcore most clients currently use, although not for long, as most clients are in the process of switching to TokTok/c-toxcore.</p>
+			</div>
+		</div>
+
+		<div id="toktok-c-toxcore" class="modalDialog button">
+			<div>
+				<a href="#close" class="close-overlay"></a>
+				<a href="#close" title="Close" class="close"><span class="fa fa-close">&nbsp;</span></a>
+
+				<h2>TokTok/c-toxcore</h2>
+
+				<p class="lead">TokTok/c-toxcore is a fork of the original irungentoo/toxcore. Toxcore developer, irungentoo, has been very busy lately and unable to find time to work on Toxcore. Because any change to Toxcore should be first reviewed and approved by irungentoo, as he is the only one who can merge changes, Toxcore development has been stalled for some time now. To get around this, a non-hostile Toxcore fork was created where the development is currently ongoing.</p>
 			</div>
 		</div>
 	</section>

--- a/themes/website/templates/download.html
+++ b/themes/website/templates/download.html
@@ -84,6 +84,29 @@
 		</div>
 	</section>
 
+	<section id="fordevelopers" class="features">
+		<h1>For Developers:</h1>
+		<br>
+		<div class="container-fluid limit-width">
+			<div class="row">
+				<div class="col-sm-6 feature">
+					<h2>Toxcore</h2>
+					<p class="lead"><a href="https://github.com/TokTok/c-toxcore">GitHub</a></p>
+				</div>
+
+				<div class="col-sm-6 feature">
+					<h2>Language bindings</h2>
+					<p class="lead">C#: <a href="https://github.com/Impyy/SharpTox">SharpTox</a></p>
+					<p class="lead" style="margin-top:-15px;">Go: <a href="https://github.com/codedust/go-tox">go-tox</a></p>
+					<p class="lead" style="margin-top:-15px;">Java/Scala: <a href="https://github.com/TokTok/jvm-toxcore-c">jvm-toxcore-c</a></p>
+					<p class="lead" style="margin-top:-15px;">Objective-C/Swift: <a href="https://github.com/Antidote-for-Tox/objcTox">objcTox</a></p>
+					<p class="lead" style="margin-top:-15px;">Python: <a href="https://github.com/aitjcize/PyTox">PyTox</a> / <a href="https://github.com/abbat/pytoxcore">pytoxcore</a></p>
+					<p class="lead" style="margin-top:-15px;">Vala: <a href="https://git.ricin.im/Ricin/tox-vapis">Tox VAPIs</a></p>
+				</div>
+			</div>
+		</div>
+	</section>
+
 	<section id="modals">
 		<div id="gnulinux" class="modalDialog button">
 			<div>

--- a/themes/website/templates/download.html
+++ b/themes/website/templates/download.html
@@ -92,12 +92,12 @@
 				<div class="col-sm-6 feature">
 					<h2>Toxcore</h2>
 					<p class="lead">
-						<a href="https://github.com/irungentoo/toxcore">irungentoo/toxcore</a>
-						<a class="button" href="#irungentoo-toxcore" title="More info"><span class="fa fa-info-circle"></span></a>
-					</p>
-					<p class="lead" style="margin-top:-15px;">
 						<a href="https://github.com/TokTok/c-toxcore">TokTok/c-toxcore</a>
 						<a class="button" href="#toktok-c-toxcore" title="More info"><span class="fa fa-info-circle"></span></a>
+					</p>
+					<p class="lead" style="margin-top:-15px;">
+						<a href="https://github.com/irungentoo/toxcore">irungentoo/toxcore</a>
+						<a class="button" href="#irungentoo-toxcore" title="More info"><span class="fa fa-info-circle"></span></a>
 					</p>
 				</div>
 

--- a/themes/website/templates/download.html
+++ b/themes/website/templates/download.html
@@ -90,8 +90,9 @@
 		<div class="container-fluid limit-width">
 			<div class="row">
 				<div class="col-sm-6 feature">
-					<h2>Toxcore</h2>
-					<p class="lead"><a href="https://github.com/TokTok/c-toxcore">GitHub</a></p>
+					<h2>Toxcore development repositories</h2>
+					<p class="lead"><a href="https://github.com/irungentoo/toxcore">irungentoo/toxcore</a></p>
+					<p class="lead"><a href="https://github.com/TokTok/c-toxcore">TokTok/c-toxcore</a></p>
 				</div>
 
 				<div class="col-sm-6 feature">


### PR DESCRIPTION
Also added dark versions of plain.svg and unknown.svg as those icons looked alright as icon representing the developer section for now.
Fixes #130 
