### PR TITLE
Updated repository links of clients

### DIFF
--- a/themes/website/templates/clients.html
+++ b/themes/website/templates/clients.html
@@ -16,7 +16,7 @@
 					<tbody>
 						<tr>
 							<th>Repository:</th>
-							<th><a href="https://github.com/tux3/qTox">https://github.com/tux3/qTox</a></th>
+							<th><a href="https://github.com/qTox/qTox">https://github.com/qTox/qTox</a></th>
 						</tr>
 						<tr>
 							<th>Maintainers:</th>
@@ -50,7 +50,7 @@
 					<tbody>
 						<tr>
 							<th>Repository:</th>
-							<th><a href="https://github.com/GrayHatter/uTox">https://github.com/GrayHatter/uTox</a></th>
+							<th><a href="https://github.com/uTox/uTox">https://github.com/uTox/uTox</a></th>
 						</tr>
 						<tr>
 							<th>Maintainers:</th>
@@ -120,7 +120,7 @@
 				<table class="table table-condensed">
 					<tbody>
 							<th>Repository:</th>
-							<th><a href="https://github.com/xveduk/toxygen">https://github.com/xveduk/toxygen</a></th>
+							<th><a href="https://github.com/toxygen-project/toxygen">https://github.com/toxygen-project/toxygen</a></th>
 						</tr>
 						<tr>
 							<th>Maintainers:</th>


### PR DESCRIPTION
Some of client repositories were moved from their author's GitHub accounts to GitHub organizations.