### PR TITLE
Fix typo on About page

### DIFF
--- a/themes/website/templates/about.html
+++ b/themes/website/templates/about.html
@@ -8,27 +8,26 @@
 			<p class="lead">
 			Tox began a few years ago, in the wake of Edward Snowden's leaks regarding NSA
 			spying activity. The idea was to create an instant messaging application that
-			ran without any kind of central servers. The system would be distributed,
-			peer-to-peer, and end-to-end encrypted, with no way to disable any of the
-			encryption features; at the same time, the application would be easily usable
-			by the layperson with no practical knowledge of cryptography or distributed
-			systems. During the Summer of 2013 a small group of developers from all around
-			the globe was formed and began working on a library implementing the Tox
+			ran without requiring the use of central servers. The system would be
+			distributed, peer-to-peer, and end-to-end encrypted, with no way to disable any
+			of the encryption features; at the same time, the application would be easily
+			usable by the layperson with no practical knowledge of cryptography or
+			distributed systems. During the Summer of 2013 a small group of developers from
+			all around the globe formed and began working on a library implementing the Tox
 			protocol. The library provides all of the messaging and encryption facilities,
 			and is completely decoupled from any user-interface; for an end-user to make
-			use of Tox, they need a Tox client. Fast-forward a few years to today, and
-			there exist several independent Tox client projects, and the original Tox core
-			library implementation is continues improving. Tox (both core library and
+			use of Tox, they need a Tox client. Fast-forward a few years to today, and there
+			exist several independent Tox client projects, and the original Tox core
+			library implementation continues to improve. Tox (both core library and
 			clients) has thousands of users, hundreds of contributors, and the project
 			shows no sign of slowing down.
 			</p>
 			<p class="lead">
 			Tox is a FOSS (Free and Open Source) project. All Tox code is open source and
 			all development occurs in the open. Tox is developed by volunteer developers who
-			spend their after work hours on it, believing in the idea of the project. Tox is
-			not a company or any other legal organization. Currently we don't accept
-			donations as a project, but you are welcome to reach out to developers
-			individually.
+			spend their free time on it, believing in the idea of the project. Tox is not a
+			company or any other legal organization. Currently we don't accept donations as
+			a project, but you are welcome to reach out to developers individually.
 			</p>
 		</div>
 	</section>
@@ -44,7 +43,7 @@
 			distribution list <a href="mailto:leadership@tox.chat">leadership@tox.chat</a>.
 			Please note that this email is not the right place to ask for general user
 			support. Please use our <a href="https://lists.tox.chat/listinfo">mailing lists
-			</a> or <a href="https://www.reddit.com/r/projecttox/">Reddit forums</a> for
+			</a> or the <a href="https://www.reddit.com/r/projecttox/">Reddit forums</a> for
 			general user support.
 			</p>
 			<p class="lead">


### PR DESCRIPTION
When revising the about page in #142 I didn't remove "is" that was there before and apparently none of the PR reviewers have noticed this. I have checked all my changes against a spellchecker, but it obviously didn't catch that as it's not a spelling error. You all know that I'm typo master and I'm not the best at English, so please proof-read my PRs more thoughtfully.

This issue was pointed out by someone emailing us.