### PR TITLE
Replace license text with GitHub page link

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -32,9 +32,9 @@ TEMPLATE_PAGES = {}
 import fnmatch
 import os
 
-templates_dir = THEME + '/templates'
-for root, dirnames, filenames in os.walk(templates_dir):
+TEMPLATES_DIR = THEME + '/templates'
+for root, dirnames, filenames in os.walk(TEMPLATES_DIR):
     for filename in fnmatch.filter(filenames, '*.html'):
         if not filename.startswith("_"):
-            template = os.path.join(root, filename)[len(templates_dir)+1:]
+            template = os.path.join(root, filename)[len(TEMPLATES_DIR)+1:]
             TEMPLATE_PAGES[template] = template

--- a/themes/website/static/css/style.css
+++ b/themes/website/static/css/style.css
@@ -415,7 +415,7 @@ tbody th:first-child, thead th {
 #footer .cc {
 	text-align: right;
 	font-size: 15px;
-	width: 280px;
+	width: 300px;
 	margin-bottom: 13px;
 }
 

--- a/themes/website/templates/_base.html
+++ b/themes/website/templates/_base.html
@@ -65,7 +65,7 @@
       <div class="cc pull-right">
         <a href="http://creativecommons.org/licenses/by-sa/4.0/"><img src="theme/img/CC.png"></a>
         <br>
-        <p>This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a></p>
+        <p>This page was generated from <a href="https://github.com/Tox/tox.chat/tree/master/{{ TEMPLATES_DIR }}/{{ self._TemplateReference__context.name }}">a file hosted in public GitHub repository</a> — issue tickets and pull requests are very welcome!</p>
       </div>
     </div>
   </footer>


### PR DESCRIPTION
Replace license text with a GitHub link to the template file the page was generated from. The license icon still shows the license and it links to http://creativecommons.org/licenses/by-sa/4.0/, so the license text was more of a filler of sorts.

Before and after:
![screen](https://cloud.githubusercontent.com/assets/1855294/21043448/f342f370-bdc4-11e6-9046-4e55e9fa6f57.png)

Inspired by https://about.gitlab.com/