### PR TITLE
Update contact information

### DIFF
--- a/themes/website/templates/about.html
+++ b/themes/website/templates/about.html
@@ -40,11 +40,12 @@
 			by some of the long-time contributors of Tox. If you have a legal question, or
 			if you notice something is wrong with tox.chat servers, or you find an outdated
 			information on the one of tox.chat websites -- you can send an email to our
-			distribution list <a href="mailto:leadership@tox.chat">leadership@tox.chat</a>.
-			Please note that this email is not the right place to ask for general user
-			support. Please use our <a href="https://lists.tox.chat/listinfo">mailing lists
-			</a> or the <a href="https://www.reddit.com/r/projecttox/">Reddit forums</a> for
-			general user support.
+			<a href="mailto:leadership@tox.chat">distribution list</a>. Please note that
+			this list is not the right place to ask for general user support. All such
+			emails would simply be ignored. Please use our
+			<a href="https://lists.tox.chat/listinfo">mailing lists</a> or the
+			<a href="https://www.reddit.com/r/projecttox/">Reddit forums</a> for general
+			user support.
 			</p>
 			<p class="lead">
 			For the reference, here is the list of the said long-time Tox contributors


### PR DESCRIPTION
Some people seem to just eyeball the webpage for the email address without reading the text around it, which explicitly says not to use it for support questions.