### PR TITLE
Add website address for qTox

### DIFF
--- a/themes/website/templates/clients.html
+++ b/themes/website/templates/clients.html
@@ -15,6 +15,10 @@
 				<table class="table table-condensed">
 					<tbody>
 						<tr>
+							<th>Website:</th>
+							<th><a href="https://qtox.github.io">https://qtox.github.io</a>
+						</tr>
+						<tr>
 							<th>Repository:</th>
 							<th><a href="https://github.com/qTox/qTox">https://github.com/qTox/qTox</a></th>
 						</tr>


### PR DESCRIPTION
Add https://qtox.github.io as qTox's website.