### PR TITLE
Update and reword descriptions of toxcores

### DIFF
--- a/themes/website/templates/download.html
+++ b/themes/website/templates/download.html
@@ -260,7 +260,7 @@ sudo apt-get update</pre>
 
 				<h2>irungentoo/toxcore</h2>
 
-				<p class="lead">irungentoo/toxcore is the original Toxcore. This repository is not active because any change to Toxcore should be first reviewed and approved by irungentoo, as he is the only one who can merge changes, but irungentoo has been very busy lately and unable to find time to work on Toxcore. He only finds time to fix bugs in Toxcore. Also, this is the Toxcore most clients currently use, although not for long, as most clients are in the process of switching to TokTok/c-toxcore.</p>
+				<p class="lead">irungentoo/toxcore is the original Toxcore. This repository is not active anymore because irungentoo wants any changes to be reviewed and approved by him, but he has been unable to find time to work on Toxcore to do the said reviews and approvals. In order to continue the development of Toxcore, the TokTok/c-toxcore non-hostile fork has been made by active Toxcore developers where the development is currently ongoing. If you are deciding which Toxcore to use, TokTok/c-toxcore is the right one.</p>
 			</div>
 		</div>
 
@@ -271,7 +271,7 @@ sudo apt-get update</pre>
 
 				<h2>TokTok/c-toxcore</h2>
 
-				<p class="lead">TokTok/c-toxcore is a fork of the original irungentoo/toxcore. Toxcore developer, irungentoo, has been very busy lately and unable to find time to work on Toxcore. Because any change to Toxcore should be first reviewed and approved by irungentoo, as he is the only one who can merge changes, Toxcore development has been stalled for some time now. To get around this, a non-hostile Toxcore fork was created where the development is currently ongoing.</p>
+				<p class="lead">TokTok/c-toxcore is a non-hostile fork of the original irungentoo/toxcore. The fork was made by active Toxcore developers due to irungentoo wanting to review and approve any changes submitted into his repository, but being unable to do so as he is unable to find time to work on Toxcore. This is the Toxcore that is being actively developed and this is also the Toxcore that all clients use.</p>
 			</div>
 		</div>
 	</section>


### PR DESCRIPTION
Mainly to change the

>Also, this is the Toxcore most clients currently use, although not for long, as most clients are in the process of switching to TokTok/c-toxcore.

part, since it's not accurate anymore, pretty much all clients now use TokTok/c-toxcore, aside from Toxygen.