### PR TITLE
Fix qTox nightly download links

### DIFF
--- a/themes/website/templates/download.html
+++ b/themes/website/templates/download.html
@@ -37,7 +37,7 @@
 					<img src="theme/img/plat/windows_dark.svg">
 					<h2>Windows</h2>
 					<p class="lead">qTox stable: <a href="https://build.tox.chat/view/qtox/job/qTox_pkg_windows_x86_stable_release/lastSuccessfulBuild/artifact/setup-qtox.exe">32 bit</a> / <a href="https://build.tox.chat/view/qtox/job/qTox_pkg_windows_x86-64_stable_release/lastSuccessfulBuild/artifact/setup-qtox.exe">64 bit</a></p>
-					<p class="lead" style="margin-top:-15px;">qTox nightly: <a href="https://build.tox.chat/view/qtox/job/qTox_build_windows_x86_release/lastSuccessfulBuild/artifact/qTox_build_windows_x86_release.zip">32 bit</a> / <a href="https://build.tox.chat/view/qtox/job/qTox_build_windows_x86-64_release/lastSuccessfulBuild/artifact/qTox_build_windows_x86-64_release.zip">64 bit</a></p>
+					<p class="lead" style="margin-top:-15px;">qTox nightly: <a href="https://build.tox.chat/view/qtox/job/qTox-cmake-nightly_build_windows_x86_release/lastSuccessfulBuild/artifact/qTox-cmake-nightly_build_windows_x86_release.zip">32 bit</a> / <a href="https://build.tox.chat/view/qtox/job/qTox-cmake-nightly_build_windows_x86-64_release/lastSuccessfulBuild/artifact/qTox-cmake-nightly_build_windows_x86-64_release.zip">64 bit</a></p>
 					<p class="lead" style="margin-top:-15px;">uTox stable: <a href="https://downloads.utox.io/stable/uTox_win32.exe"> 32 bit</a> / <a href="https://downloads.utox.io/stable/uTox_win64.exe">64 bit</a></p>
 				</div>
 


### PR DESCRIPTION
qTox uses the `-cmake` prefixed build jobs now.

Fixes #188.