### PR TITLE
Fix image path

### DIFF
--- a/themes/website/templates/_base.html
+++ b/themes/website/templates/_base.html
@@ -19,7 +19,7 @@
   <meta property="og:title" content="A New Kind of Instant Messaging"/>
   <meta property="og:type" content="website"/>
   <meta property="og:url" content="https://tox.chat"/>
-  <meta property="og:image" content="https://tox.chat/img/toxvert.png"/>
+  <meta property="og:image" content="https://tox.chat/theme/img/toxvert.png"/>
   <meta property="og:site_name" content="Project Tox"/>
   <meta property="og:description" content="Whether it's corporations or governments, there's just too much digital spying going on today. Tox is an easy to use application that connects you with friends and family without anyone else listening in. While other big-name services require you to pay for features, Tox is totally free and comes without advertising &mdash; forever."/>
   {% endblock %}


### PR DESCRIPTION
https://tox.chat/img/toxvert.png is HTTP 404, the correct path is https://tox.chat/theme/img/toxvert.png -- pelican quirks. I thought I have fixed all links then switching to Pelican, but apparently not.