### PR TITLE
link to Github for qTox releases

### DIFF
--- a/themes/website/static/js/osdetect.js
+++ b/themes/website/static/js/osdetect.js
@@ -129,7 +129,7 @@ if (window.navigator.userAgent.indexOf("Windows") != -1) {
 			name: "qtox",
 			icon: "download",
 			desc: true,
-			dlLink: "https://build.tox.chat/view/qtox/job/qTox_pkg_windows_x86-64_stable_release/lastSuccessfulBuild/artifact/setup-qtox.exe",
+			dlLink: "https://github.com/qTox/qTox/releases/download/v1.15.0/setup-qtox-x86_64-release.exe",
 		}, {
 			title: "uTox 64-bit",
 			name: "utox",
@@ -143,7 +143,7 @@ if (window.navigator.userAgent.indexOf("Windows") != -1) {
 			name: "qtox",
 			icon: "download",
 			desc: true,
-			dlLink: "https://build.tox.chat/view/qtox/job/qTox_pkg_windows_x86_stable_release/lastSuccessfulBuild/artifact/setup-qtox.exe",
+			dlLink: "https://github.com/qTox/qTox/releases/download/v1.15.0/setup-qtox-i686-release.exe",
 		}, {
 			title: "uTox 32-bit",
 			name: "utox",

--- a/themes/website/templates/download.html
+++ b/themes/website/templates/download.html
@@ -36,7 +36,7 @@
 				<div class="col-sm-4 feature">
 					<img src="theme/img/plat/windows_dark.svg">
 					<h2>Windows</h2>
-					<p class="lead">qTox stable: <a href="https://build.tox.chat/view/qtox/job/qTox_pkg_windows_x86_stable_release/lastSuccessfulBuild/artifact/setup-qtox.exe">32 bit</a> / <a href="https://build.tox.chat/view/qtox/job/qTox_pkg_windows_x86-64_stable_release/lastSuccessfulBuild/artifact/setup-qtox.exe">64 bit</a></p>
+					<p class="lead">qTox stable: <a href="https://github.com/qTox/qTox/releases/download/v1.15.0/setup-qtox-i686-release.exe">32 bit</a> / <a href="https://github.com/qTox/qTox/releases/download/v1.15.0/setup-qtox-x86_64-release.exe">64 bit</a></p>
 					<p class="lead" style="margin-top:-15px;">qTox nightly: <a href="https://build.tox.chat/view/qtox/job/qTox-cmake-nightly_build_windows_x86_release/lastSuccessfulBuild/artifact/qTox-cmake-nightly_build_windows_x86_release.zip">32 bit</a> / <a href="https://build.tox.chat/view/qtox/job/qTox-cmake-nightly_build_windows_x86-64_release/lastSuccessfulBuild/artifact/qTox-cmake-nightly_build_windows_x86-64_release.zip">64 bit</a></p>
 					<p class="lead" style="margin-top:-15px;">uTox stable: <a href="https://downloads.utox.io/stable/uTox_win32.exe"> 32 bit</a> / <a href="https://downloads.utox.io/stable/uTox_win64.exe">64 bit</a></p>
 				</div>


### PR DESCRIPTION
We have decided to serve our release builds from Github releases from now on. Nightly builds stay on build.tox.chat in the near time.