### PR TITLE
Remove strong claims for efficacy of the onion from the faq

### DIFF
--- a/themes/website/templates/faq.html
+++ b/themes/website/templates/faq.html
@@ -27,7 +27,6 @@
 				<p class="lead">Tox protects your privacy by:</p>
 				<ul>
 					<li>Removing the need to rely on central authorities to provide messenger services</li>
-					<li>Concealing your identity (in the form of meta-data, e.g. your IP address) from people who are not your authorized friends</li>
 					<li>Enforcing end-to-end encryption with <a href="https://en.wikipedia.org/wiki/Forward_secrecy">perfect forward secrecy</a> as the default and only mode of operation for all messages</li>
 					<li>Making your identity impossible to forge without the possesion of your personal private key, which never leaves your computer</li>
 				</ul>
@@ -53,7 +52,7 @@
 			<div id="tox-leak-ip">
 				<h3>Does Tox leak my IP address?</h3>
 
-				<p class="lead">Tox makes no attempt to cloak your IP address when communicating with friends, as the whole point of a peer-to-peer network is to connect you directly to your friends. A workaround does exist in the form of tunneling your Tox connections through Tor. However, a non-friend user cannot discover your IP address using only a Tox ID; your IP address will only be discernible when you accept/send a friend request, and add a user to your contacts list.</p>
+				<p class="lead">Tox makes no attempt to cloak your IP address when communicating with friends, as the whole point of a peer-to-peer network is to connect you directly to your friends. A workaround does exist in the form of tunneling your Tox connections through Tor. However, a non-friend user cannot easily discover your IP address using only a Tox ID; you reveal your IP address to someone only when you add them to your contacts list.</p>
 
 				<p class="lead">See Also: <a href="#tox-tracking-dht">What is stopping people from tracking me through the public DHT (advanced)</a>.</p>
 			</div>


### PR DESCRIPTION
In the light of the known vulnerabilities in the onion (see
https://github.com/TokTok/c-toxcore/issues/1152 ), I think we should
avoid claiming too much for it.