### PR TITLE
Remove social media buttons from the footer

### DIFF
--- a/themes/website/templates/_base.html
+++ b/themes/website/templates/_base.html
@@ -55,8 +55,6 @@
       </div>
 
       <div class="ext-med pull-left">
-        <a class="button" href="https://twitter.com/projecttox" title="Follow us on Twitter"><span class="icon fa fa-twitter"></span></a>
-        <a class="button" href="https://www.facebook.com/toxproject" title="Like us on Facebook"><span class="icon fa fa-facebook"></span></a>
         <a class="button" href="https://github.com/TokTok/c-toxcore" title="Star us on Github"><span class="icon fa fa-github"></span></a>
         <a class="button" href="https://wiki.tox.chat/users/community#irc" title="Chat with us on IRC"><span class="icon fa fa-comments"></span></a>
         <a class="button do-button" href="https://www.digitalocean.com/" title="Powered by DigitalOcean"><img class="button" src="theme/img/do.svg" /></a>


### PR DESCRIPTION
It appears that we have already removed the links in the footer of toktok.ltd that link to our facebook and twitter accounts. I believe that having people visit tox.chat and seeing those buttons paints a picture of toktok being nonchalant when it comes to our commitment to security and privacy. Also, those accounts seem to be inactive, so there is no real benefit of showing how inactive we are there.