### PR TITLE
Update qTox to v1.18.3

### DIFF
--- a/themes/website/static/css/style.css
+++ b/themes/website/static/css/style.css
@@ -283,7 +283,6 @@ tbody th:first-child, thead th {
 #cover .button.download {
 	background: #FFBA2B;
 	color: #fff;
-	width: 210px;
 }
 
 #cover .button.download:hover {

--- a/themes/website/static/js/osdetect.js
+++ b/themes/website/static/js/osdetect.js
@@ -34,17 +34,29 @@ if (window.navigator.userAgent.indexOf("Mac") != -1) {
 	OSName = "Mac";
 
 	clients = [{
-		title: "qTox (Apple Sillicon)",
+		title: "qTox (macOS 12+, Apple Silicon)",
 		name: "qtox",
 		icon: "download",
 		desc: true,
-		dlLink: "https://github.com/TokTok/qTox/releases/download/v1.18.2/qTox-arm64.dmg",
+		dlLink: "https://github.com/TokTok/qTox/releases/download/v1.18.3/qTox-v1.18.3.arm64-12.0.dmg",
 	}, {
-		title: "qTox (Intel)",
+		title: "qTox (macOS 10.15+, Apple Silicon)",
 		name: "qtox",
 		icon: "download",
 		desc: true,
-		dlLink: "https://github.com/TokTok/qTox/releases/download/v1.18.2/qTox-x86_64.dmg",
+		dlLink: "https://github.com/TokTok/qTox/releases/download/v1.18.3/qTox-v1.18.3.arm64-10.15.dmg",
+	}, {
+		title: "qTox (macOS 12+, Intel)",
+		name: "qtox",
+		icon: "download",
+		desc: true,
+		dlLink: "https://github.com/TokTok/qTox/releases/download/v1.18.3/qTox-v1.18.3.x86_64-12.0.dmg",
+	}, {
+		title: "qTox (macOS 10.15+, Intel)",
+		name: "qtox",
+		icon: "download",
+		desc: true,
+		dlLink: "https://github.com/TokTok/qTox/releases/download/v1.18.3/qTox-v1.18.3.x86_64-10.15.dmg",
 	}];
 }
 
@@ -111,7 +123,7 @@ if (window.navigator.userAgent.indexOf("Windows") != -1) {
 			name: "qtox",
 			icon: "download",
 			desc: true,
-			dlLink: "https://github.com/TokTok/qTox/releases/download/v1.18.2/setup-qtox-x86_64-release.exe",
+			dlLink: "https://github.com/TokTok/qTox/releases/download/v1.18.3/setup-qtox-x86_64-release.exe",
 		}];
 	} else {
 		clients = [{
@@ -119,7 +131,7 @@ if (window.navigator.userAgent.indexOf("Windows") != -1) {
 			name: "qtox",
 			icon: "download",
 			desc: true,
-			dlLink: "https://github.com/TokTok/qTox/releases/download/v1.18.2/setup-qtox-i686-release.exe",
+			dlLink: "https://github.com/TokTok/qTox/releases/download/v1.18.3/setup-qtox-i686-release.exe",
 		}];
 	}
 }

--- a/themes/website/templates/download.html
+++ b/themes/website/templates/download.html
@@ -36,22 +36,24 @@
 				<div class="col-sm-4 feature">
 					<img src="theme/img/plat/windows_dark.svg">
 					<h2>Windows</h2>
-					<p class="lead">qTox: <a href="https://github.com/TokTok/qTox/releases/download/v1.18.2/setup-qtox-i686-release.exe">32 bit</a> / <a href="https://github.com/TokTok/qTox/releases/download/v1.18.2/setup-qtox-x86_64-release.exe">64 bit</a></p>
+					<p class="lead">qTox: <a href="https://github.com/TokTok/qTox/releases/download/v1.18.3/setup-qtox-i686-release.exe">32 bit</a> / <a href="https://github.com/TokTok/qTox/releases/download/v1.18.3/setup-qtox-x86_64-release.exe">64 bit</a></p>
 					<p class="lead" style="margin-top:-15px;">qTox nightly: <a href="https://github.com/TokTok/qTox/releases/download/nightly/qtox-nightly-i686-Release.zip">32 bit</a> / <a href="https://github.com/TokTok/qTox/releases/download/nightly/qtox-nightly-x86_64-Release.zip">64 bit</a></p>
 				</div>
 
 				<div class="col-sm-4 feature">
 					<img src="theme/img/plat/mac_dark.svg">
 					<h2>macOS</h2>
-					<p class="lead">qTox: <a href="https://github.com/TokTok/qTox/releases/download/v1.18.2/qTox-arm64.dmg">Apple Sillicon</a> / <a href="https://github.com/TokTok/qTox/releases/download/v1.18.2/qTox-x86_64.dmg">Intel</a></p>
-					<p class="lead" style="margin-top:-15px;">qTox nightly: <a href="https://github.com/TokTok/qTox/releases/download/nightly/qTox-nightly-arm64.dmg">Apple Sillicon</a> / <a href="https://github.com/TokTok/qTox/releases/download/nightly/qTox-nightly-x86_64.dmg">Intel</a></p>
+					<p class="lead">qTox macOS 12+: <a href="https://github.com/TokTok/qTox/releases/download/v1.18.3/qTox-v1.18.3.arm64-12.0.dmg">Apple Silicon</a> / <a href="https://github.com/TokTok/qTox/releases/download/v1.18.3/qTox-v1.18.3.x86_64-12.0.dmg">Intel</a></p>
+					<p class="lead" style="margin-top:-15px;">qTox macOS 10.15+: <a href="https://github.com/TokTok/qTox/releases/download/v1.18.3/qTox-v1.18.3.arm64-10.15.dmg">Apple Silicon</a> / <a href="https://github.com/TokTok/qTox/releases/download/v1.18.3/qTox-v1.18.3.x86_64-10.15.dmg">Intel</a></p>
+					<p class="lead" style="margin-top:-15px;">qTox nightly macOS 12+: <a href="https://github.com/TokTok/qTox/releases/download/nightly/qTox-nightly-arm64-12.0.dmg">Apple Silicon</a> / <a href="https://github.com/TokTok/qTox/releases/download/nightly/qTox-nightly-x86_64-12.0.dmg">Intel</a></p>
+					<p class="lead" style="margin-top:-15px;">qTox nightly macOS 10.5+: <a href="https://github.com/TokTok/qTox/releases/download/nightly/qTox-nightly-arm64-10.15.dmg">Apple Silicon</a> / <a href="https://github.com/TokTok/qTox/releases/download/nightly/qTox-nightly-x86_64-10.15.dmg">Intel</a></p>
 				</div>
 
 				<div class="col-sm-4 feature">
 					<img src="theme/img/plat/linux_dark.svg">
 					<h2>Linux</h2>
 					<p class="lead">Please check in the package repository of your distribution.</p>
-					<p class="lead">qTox: <a href="https://flathub.org/apps/details/io.github.qtox.qTox">Flathub</a> / <a href="https://github.com/TokTok/qTox/releases/download/v1.18.2/qTox-v1.18.2-x86_64.AppImage">AppImage</a></p>
+					<p class="lead">qTox: <a href="https://flathub.org/apps/details/io.github.qtox.qTox">Flathub</a> / <a href="https://github.com/TokTok/qTox/releases/download/v1.18.3/qTox-v1.18.3-x86_64.AppImage">AppImage</a></p>
 					<p class="lead" style="margin-top:-15px;">qTox nightly: <a href="https://github.com/TokTok/qTox/releases/download/nightly/qTox-nightly.flatpak">Flatpak</a> / <a href="https://github.com/TokTok/qTox/releases/download/nightly/qTox-nightly-x86_64.AppImage">AppImage</a></p>
 					<p class="lead" style="margin-top:-15px;">Toxic minimal fully static: <a href="https://github.com/Jfreegman/toxic/releases/download/v0.16.1/toxic-minimal-static-musl_linux_x86.tar.xz">32-bit</a> / <a href="https://github.com/Jfreegman/toxic/releases/download/v0.16.1/toxic-minimal-static-musl_linux_x86-64.tar.xz">64-bit</a></p>
 				</div>


### PR DESCRIPTION
Added links for both macOS 10.5 and 12.0 downloads.

Removed the fixed width on the download button because text like "qTox (macOS 10.15+, Apple Sillicon)" was way too long to fit into that width, making it look ugly.