### PR TITLE
macOS 10.5 > 10.15

### DIFF
--- a/themes/website/templates/download.html
+++ b/themes/website/templates/download.html
@@ -46,7 +46,7 @@
 					<p class="lead">qTox macOS 12+: <a href="https://github.com/TokTok/qTox/releases/download/v1.18.3/qTox-v1.18.3.arm64-12.0.dmg">Apple Silicon</a> / <a href="https://github.com/TokTok/qTox/releases/download/v1.18.3/qTox-v1.18.3.x86_64-12.0.dmg">Intel</a></p>
 					<p class="lead" style="margin-top:-15px;">qTox macOS 10.15+: <a href="https://github.com/TokTok/qTox/releases/download/v1.18.3/qTox-v1.18.3.arm64-10.15.dmg">Apple Silicon</a> / <a href="https://github.com/TokTok/qTox/releases/download/v1.18.3/qTox-v1.18.3.x86_64-10.15.dmg">Intel</a></p>
 					<p class="lead" style="margin-top:-15px;">qTox nightly macOS 12+: <a href="https://github.com/TokTok/qTox/releases/download/nightly/qTox-nightly-arm64-12.0.dmg">Apple Silicon</a> / <a href="https://github.com/TokTok/qTox/releases/download/nightly/qTox-nightly-x86_64-12.0.dmg">Intel</a></p>
-					<p class="lead" style="margin-top:-15px;">qTox nightly macOS 10.5+: <a href="https://github.com/TokTok/qTox/releases/download/nightly/qTox-nightly-arm64-10.15.dmg">Apple Silicon</a> / <a href="https://github.com/TokTok/qTox/releases/download/nightly/qTox-nightly-x86_64-10.15.dmg">Intel</a></p>
+					<p class="lead" style="margin-top:-15px;">qTox nightly macOS 10.15+: <a href="https://github.com/TokTok/qTox/releases/download/nightly/qTox-nightly-arm64-10.15.dmg">Apple Silicon</a> / <a href="https://github.com/TokTok/qTox/releases/download/nightly/qTox-nightly-x86_64-10.15.dmg">Intel</a></p>
 				</div>
 
 				<div class="col-sm-4 feature">


### PR DESCRIPTION
I don't think qTox was ever available on 10.5. A typo?